### PR TITLE
fix: история платежей (сессии + мероприятия), одна карта

### DIFF
--- a/backend/src/payments/payment-methods.service.ts
+++ b/backend/src/payments/payment-methods.service.ts
@@ -53,8 +53,8 @@ export class PaymentMethodsService {
       },
     });
 
-    if (activeCardsCount >= 3) {
-      throw new ConflictException('Максимум можно привязать 3 карты');
+    if (activeCardsCount >= 1) {
+      throw new ConflictException('Можно привязать только одну карту. Удалите текущую, чтобы привязать другую.');
     }
 
     const paymentMethod = this.paymentMethodRepository.create({

--- a/backend/src/payments/payments.controller.ts
+++ b/backend/src/payments/payments.controller.ts
@@ -55,13 +55,17 @@ export class PaymentsController {
       success: true,
       data: result.data.map((p) => ({
         id: p.id,
+        kind: p.kind,
         amount: p.amount,
         currency: p.currency,
         status: p.status,
         createdAt: p.createdAt,
         paidAt: p.paidAt,
         sessionId: p.sessionId,
-        tutorName: p.tutor?.fullName || null,
+        eventId: p.eventId,
+        eventTitle: p.eventTitle,
+        tutorName: p.counterpartyName,
+        counterpartyName: p.counterpartyName,
         errorMessage: p.errorMessage || null,
       })),
       pagination: {

--- a/backend/src/payments/payments.service.ts
+++ b/backend/src/payments/payments.service.ts
@@ -20,6 +20,22 @@ import { TransactionStatus, TransactionType } from './entities/transaction.entit
 import { UserEvent, ParticipationStatus, PaymentStatus as UserEventPaymentStatus } from 'src/events/entities/user-event.entity';
 import { Event } from 'src/events/entities/event.entity';
 
+/** Строка истории платежей в профиле (сессии + мероприятия). */
+export type StudentPaymentHistoryItem = {
+  id: string;
+  kind: 'session' | 'event';
+  amount: number;
+  currency: string;
+  status: PaymentStatus;
+  createdAt: Date;
+  paidAt: Date | null;
+  sessionId: string | null;
+  eventId: string | null;
+  eventTitle: string | null;
+  counterpartyName: string | null;
+  errorMessage: string | null;
+};
+
 @Injectable()
 export class PaymentsService {
   private readonly logger = new Logger(PaymentsService.name);
@@ -214,20 +230,78 @@ export class PaymentsService {
     return payment;
   }
 
+  /** История для профиля: оплаты сессий (таблица payments) + оплаченные мероприятия (user_events), т.к. события раньше не создавали запись в payments. */
   async getStudentPayments(
     userId: string,
     page = 1,
     limit = 20
-  ): Promise<{ data: Payment[]; total: number; page: number; limit: number }> {
+  ): Promise<{
+    data: StudentPaymentHistoryItem[];
+    total: number;
+    page: number;
+    limit: number;
+  }> {
     const skip = (page - 1) * limit;
 
-    const [data, total] = await this.paymentRepository.findAndCount({
-      where: { userId },
-      relations: ['session', 'tutor'],
-      order: { createdAt: 'DESC' },
-      skip,
-      take: limit,
+    const [sessionPayments, paidEvents] = await Promise.all([
+      this.paymentRepository.find({
+        where: { userId },
+        relations: ['session', 'tutor'],
+        order: { createdAt: 'DESC' },
+      }),
+      this.userEventRepository.find({
+        where: { userId, paymentStatus: UserEventPaymentStatus.PAID },
+        relations: ['event', 'event.mentor'],
+        order: { updatedAt: 'DESC' },
+      }),
+    ]);
+
+    const sessionItems = sessionPayments.map((p) => ({
+      row: {
+        id: p.id,
+        kind: 'session' as const,
+        amount: Number(p.amount),
+        currency: p.currency,
+        status: p.status,
+        createdAt: p.createdAt,
+        paidAt: p.paidAt ?? null,
+        sessionId: p.sessionId ?? null,
+        eventId: null,
+        eventTitle: null,
+        counterpartyName: p.tutor?.fullName ?? null,
+        errorMessage: p.errorMessage ?? null,
+      } satisfies StudentPaymentHistoryItem,
+      sortAt: p.paidAt ?? p.createdAt,
+    }));
+
+    const eventItems = paidEvents.map((ue) => {
+      const ev = ue.event;
+      const paidAt = ue.updatedAt;
+      return {
+        row: {
+          id: ue.id,
+          kind: 'event' as const,
+          amount: ev ? Number(ev.price) : 0,
+          currency: 'RUB',
+          status: PaymentStatus.SUCCESS,
+          createdAt: ue.createdAt,
+          paidAt,
+          sessionId: null,
+          eventId: ue.eventId,
+          eventTitle: ev?.title ?? null,
+          counterpartyName: ev?.mentor?.fullName ?? null,
+          errorMessage: null,
+        } satisfies StudentPaymentHistoryItem,
+        sortAt: paidAt,
+      };
     });
+
+    const merged = [...sessionItems, ...eventItems].sort(
+      (a, b) => b.sortAt.getTime() - a.sortAt.getTime()
+    );
+
+    const total = merged.length;
+    const data = merged.slice(skip, skip + limit).map((m) => m.row);
 
     return { data, total, page, limit };
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Изменения

### Платежи и карты (ранее)
- **История платежей (`GET /student/payments`)**: объединение оплат сессий и оплаченных мероприятий (`user_events`), поля `kind`, `eventId`, `eventTitle`, `tutorName` / `counterpartyName`.
- **Одна карта**: не более одной активной привязки.

### Лента и «мои события» (этот коммит)
- **`GET /events/feed`**: для авторизованного пользователя **не** возвращаются события, на которые он уже записан (есть строка в `user_events` со статусом не `cancelled`).
- **`GET /events/my` (role=student)**: в список «моих» событий добавлен статус участия **`pending`** (ожидание оплаты), чтобы не терялись записи на платные мероприятия до оплаты.

## Примечание для фронтенда

См. комментарии в PR по интеграции `/student/bookings`, `/events/my`, `/student/payment-methods` и `/student/payments`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eec5c87e-4490-48eb-939f-3f5a955e5051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eec5c87e-4490-48eb-939f-3f5a955e5051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

